### PR TITLE
Integrate gutenberg-mobile release 99.99.99

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -154,7 +154,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :tag => 'v1.42.0-alpha2'
+    gutenberg :commit => '0403b64af582a0632de4c91f195e29b9ace254f1'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
   - GTMSessionFetcher/Core (1.5.0)
   - GTMSessionFetcher/Full (1.5.0):
     - GTMSessionFetcher/Core (= 1.5.0)
-  - Gutenberg (1.41.1):
+  - Gutenberg (99.99.99):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -381,7 +381,7 @@ PODS:
     - React
   - RNSVG (9.13.6-gb):
     - React
-  - RNTAztecView (1.41.1):
+  - RNTAztecView (99.99.99):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.3)
   - Sentry (4.5.0):
@@ -449,14 +449,14 @@ DEPENDENCIES:
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.2)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.42.0-alpha2`)
+  - Gutenberg (from `http://github.com/cameronvoell/gutenberg-mobile/`, commit `0403b64af582a0632de4c91f195e29b9ace254f1`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
@@ -466,41 +466,41 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-blur.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-safe-area-context (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-safe-area-context.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNCMaskedView (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNCMaskedView.podspec.json`)
-  - RNGestureHandler (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNGestureHandler.podspec.json`)
-  - RNReanimated (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNReanimated.podspec.json`)
-  - RNScreens (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNScreens.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.42.0-alpha2`)
+  - React (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-blur (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-blur.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-safe-area-context (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-safe-area-context.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNCMaskedView (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNCMaskedView.podspec.json`)
+  - RNGestureHandler (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNGestureHandler.podspec.json`)
+  - RNReanimated (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNReanimated.podspec.json`)
+  - RNScreens (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNScreens.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/cameronvoell/gutenberg-mobile/`, commit `0403b64af582a0632de4c91f195e29b9ace254f1`)
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
@@ -510,7 +510,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.13.0)
   - WordPressUI (~> 1.7.4-beta.1)
   - WPMediaPicker (~> 1.7.2)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.1.1)
   - ZIPFoundation (~> 0.9.8)
 
@@ -571,108 +571,108 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :commit: 0403b64af582a0632de4c91f195e29b9ace254f1
+    :git: http://github.com/cameronvoell/gutenberg-mobile/
     :submodules: true
-    :tag: v1.42.0-alpha2
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-jsinspector.podspec.json
   react-native-blur:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-blur.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-blur.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-safe-area-context:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-safe-area-context.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-safe-area-context.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNCMaskedView:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNCMaskedView.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNCMaskedView.podspec.json
   RNGestureHandler:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNGestureHandler.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNGestureHandler.podspec.json
   RNReanimated:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNReanimated.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNReanimated.podspec.json
   RNScreens:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNScreens.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNScreens.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :commit: 0403b64af582a0632de4c91f195e29b9ace254f1
+    :git: http://github.com/cameronvoell/gutenberg-mobile/
     :submodules: true
-    :tag: v1.42.0-alpha2
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.42.0-alpha2/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0403b64af582a0632de4c91f195e29b9ace254f1/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :commit: 0403b64af582a0632de4c91f195e29b9ace254f1
+    :git: http://github.com/cameronvoell/gutenberg-mobile/
     :submodules: true
-    :tag: v1.42.0-alpha2
   RNCMaskedView:
     :commit: d4ccf2bba163679c4550ce6ba0119604cd5e6379
     :git: https://github.com/react-native-community/react-native-masked-view.git
   RNTAztecView:
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :commit: 0403b64af582a0632de4c91f195e29b9ace254f1
+    :git: http://github.com/cameronvoell/gutenberg-mobile/
     :submodules: true
-    :tag: v1.42.0-alpha2
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -700,7 +700,7 @@ SPEC CHECKSUMS:
   Gridicons: 7085561c06c2bda3a78f4a14f6590e61c3bfd09a
   GTMAppAuth: 197a8dabfea5d665224aa00d17f164fc2248dab9
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Gutenberg: 74a57d7039b81a60cf51ae799da2718d5de75255
+  Gutenberg: ab0415bd11379e69e43ad5e17861cc9d3940300f
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   MediaEditor: 20cdeb46bdecd040b8bc94467ac85a52b53b193a
@@ -744,7 +744,7 @@ SPEC CHECKSUMS:
   RNReanimated: 13f7a6a22667c4f00aac217bc66f94e8560b3d59
   RNScreens: 6833ac5c29cf2f03eed12103140530bbd75b6aea
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: 6528dc19b67821dcfdc9ee22c661dae2690e5484
+  RNTAztecView: 255516254645e53b0a773aa121014f6c0060c250
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
@@ -769,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 34b5c72775fbff284456df949043c4c065731303
+PODFILE CHECKSUM: e9148c62935f4cd83fe38d61bc94e6268febccd5
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
## Description
This PR incorporates the 99.99.99 release of gutenberg-mobile.  
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/cameronvoell/gutenberg-mobile/pull/39

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.