### PR TITLE
Integrate gutenberg-mobile release 99.99.99

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -86,7 +86,7 @@ def shared_with_extension_pods
 end
 
 def gutenberg(options)
-    options[:git] = 'https://github.com/wordpress-mobile/gutenberg-mobile.git'
+    options[:git] = 'https://github.com/cameronvoell/gutenberg-mobile.git'
     options[:submodules] = true
     local_gutenberg = ENV['LOCAL_GUTENBERG']
     if local_gutenberg
@@ -161,7 +161,7 @@ abstract_target 'Apps' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :tag => 'v1.51.0'
+    gutenberg :commit => '0abd817ec9f51699ff170a0f6aa8d832d2fe6712'
 
 
     ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -69,7 +69,7 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
-  - Gutenberg (1.51.0):
+  - Gutenberg (99.99.99):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -376,7 +376,7 @@ PODS:
     - React
   - RNSVG (9.13.6-gb):
     - React
-  - RNTAztecView (1.51.0):
+  - RNTAztecView (99.99.99):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.4)
   - Sentry (6.2.1):
@@ -443,14 +443,14 @@ DEPENDENCIES:
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.1.0)
-  - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.51.0`)
+  - Gutenberg (from `https://github.com/cameronvoell/gutenberg-mobile.git`, commit `0abd817ec9f51699ff170a0f6aa8d832d2fe6712`)
   - JTAppleCalendar (~> 8.0.2)
   - Kanvas (~> 1.2.6)
   - MediaEditor (~> 1.2.1)
@@ -460,41 +460,41 @@ DEPENDENCIES:
   - "NSURL+IDN (~> 0.4)"
   - OCMock (~> 3.4.3)
   - OHHTTPStubs/Swift (~> 9.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-blur.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-safe-area-context (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-safe-area-context.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNCMaskedView (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNCMaskedView.podspec.json`)
-  - RNGestureHandler (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNGestureHandler.podspec.json`)
-  - RNReanimated (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNReanimated.podspec.json`)
-  - RNScreens (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNScreens.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.51.0`)
+  - React (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-blur (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-blur.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-safe-area-context (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-safe-area-context.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNCMaskedView (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNCMaskedView.podspec.json`)
+  - RNGestureHandler (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNGestureHandler.podspec.json`)
+  - RNReanimated (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNReanimated.podspec.json`)
+  - RNScreens (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNScreens.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `https://github.com/cameronvoell/gutenberg-mobile.git`, commit `0abd817ec9f51699ff170a0f6aa8d832d2fe6712`)
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
@@ -504,7 +504,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.10.0)
   - WPMediaPicker (~> 1.7.2)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.2.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -567,105 +567,105 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
+    :commit: 0abd817ec9f51699ff170a0f6aa8d832d2fe6712
+    :git: https://github.com/cameronvoell/gutenberg-mobile.git
     :submodules: true
-    :tag: v1.51.0
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-jsinspector.podspec.json
   react-native-blur:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-blur.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-blur.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-safe-area-context:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-safe-area-context.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-safe-area-context.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNCMaskedView:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNCMaskedView.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNCMaskedView.podspec.json
   RNGestureHandler:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNGestureHandler.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNGestureHandler.podspec.json
   RNReanimated:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNReanimated.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNReanimated.podspec.json
   RNScreens:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNScreens.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNScreens.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
+    :commit: 0abd817ec9f51699ff170a0f6aa8d832d2fe6712
+    :git: https://github.com/cameronvoell/gutenberg-mobile.git
     :submodules: true
-    :tag: v1.51.0
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/cameronvoell/gutenberg-mobile/0abd817ec9f51699ff170a0f6aa8d832d2fe6712/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
+    :commit: 0abd817ec9f51699ff170a0f6aa8d832d2fe6712
+    :git: https://github.com/cameronvoell/gutenberg-mobile.git
     :submodules: true
-    :tag: v1.51.0
   RNTAztecView:
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
+    :commit: 0abd817ec9f51699ff170a0f6aa8d832d2fe6712
+    :git: https://github.com/cameronvoell/gutenberg-mobile.git
     :submodules: true
-    :tag: v1.51.0
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -693,7 +693,7 @@ SPEC CHECKSUMS:
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: 5b53231ef6920f149ab84b2969cb0ab572da3077
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
-  Gutenberg: d6b2d24ef7fc12c74c93f5c8304e665d0aa64a67
+  Gutenberg: f68c588c0ff404afaa7a22586dd9fba4946eaf80
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: 828033a062a8df8bd73e6efd1a09ac438ead4b41
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
@@ -738,7 +738,7 @@ SPEC CHECKSUMS:
   RNReanimated: 13f7a6a22667c4f00aac217bc66f94e8560b3d59
   RNScreens: 6833ac5c29cf2f03eed12103140530bbd75b6aea
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: 0507765fb9a1d51a0a399d63b803c411e91cebf7
+  RNTAztecView: 5cb4a962840c13fceb265d2f104228abef2a3d24
   Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
@@ -763,6 +763,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: aac1cbd1bff8bb0f956e0d1efde61d97fc334a17
+PODFILE CHECKSUM: acce6d91a250061cfdf486d485d5574b495d0f93
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
## Description
This PR incorporates the 99.99.99 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/cameronvoell/gutenberg-mobile/pull/125

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.